### PR TITLE
migrate to new ftp server for legacy diplib (version 2 and lower)

### DIFF
--- a/addons.md
+++ b/addons.md
@@ -13,30 +13,30 @@ This page provides links to
 Most of the add-ons here require *DIPimage* 2.9, and might not work with the latest release.
 You can download *DIPimage* 2.9 through the link on the side-bar.
 
-- [Calibration photon counts from a single image](ftp://qiftp.tudelft.nl/rieger/outgoing/pcfo),
+- [Calibration photon counts from a single image](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/pcfo),
   Reference: R. Heintzmann, P.K. Relich, P.P.J. Nieuwenhuizen, K.A. Lidke, B. Rieger, submitted
 
-- [Deconvolution methods for structured illumination microscopy](ftp://qiftp.tudelft.nl/rieger/outgoing/piFP_and_jRL.zip),
+- [Deconvolution methods for structured illumination microscopy](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/piFP_and_jRL.zip),
   Reference: N. Chakrova, B. Rieger, S. Stallinga,
   *Deconvolution methods for structured illumination microscopy*,
   Journal of the Optical Society of America A, **33**(7):B12-B20, 2016.
 
-- [Co-orientation](ftp://qiftp.tudelft.nl/rieger/outgoing/Coorientation_Software.zip),
+- [Co-orientation](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/Coorientation_Software.zip),
   Reference: R.P.J. Nieuwenhuizen, L. Nahidi Azar, E.M.M. Manders, K. Jalink, Stallinga, B. Rieger,
   *Co-orientation: Quantifying simultaneous co-localization and orientational alignment of filaments in light microscopy*,
   PLoS ONE, **10**(7):e0131756, 2015.
 
-- [Quantitative localization microscopy](https://qiftp.tudelft.nl/diplib/addons/QuantitativeLocMic_software.zip),
+- [Quantitative localization microscopy](https://ftp.imphys.tudelft.nl/DIPimage/addons/QuantitativeLocMic_software.zip),
   Reference: R.P.J. Nieuwenhuizen, M. Bates, A. Szymborska, K.A. Lidke, B. Rieger, S. Stallinga,
   *Quantitative localization microscopy: Effects of photophysics and labeling stoichiometry*,
   PLoS ONE, **10**(5):e0127989, 2015.
 
-- [Image Resolution](ftp://qiftp.tudelft.nl/rieger/outgoing/FRCresolution_software.zip),
+- [Image Resolution](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/FRCresolution_software.zip),
   Reference: R.P.J. Nieuwenhuizen, K.A. Lidke, M. Bates, D. Leyton Puig, D. Grünwald, S. Stallinga, B. Rieger,
   *Measuring Image Resolution in Optical Nanoscopy*,
   Nature Methods, **10**(6):557-562, 2013.
 
-- [Podosome counting](ftp://qiftp.tudelft.nl/rieger/outgoing/Meddens_podosome.zip),
+- [Podosome counting](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/Meddens_podosome.zip),
   Reference: M.B.M. Meddens, B. Rieger, C.G. Figdor, A. Cambi, K. van den Dries,
   *Automated podosome identification and characterization in fluorescence microscopy images*,
   Microscopy and Microanalysis, **19**(1):180-189, 2013.
@@ -50,17 +50,17 @@ You can download *DIPimage* 2.9 through the link on the side-bar.
   *Precise and Unbiased Estimation of Astigmatism and Defocus in Transmission Electron Microscopy*,
   Ultramicroscopy, **116**:115-134, 2012.
 
-- [Single emitter fitting](ftp://qiftp.tudelft.nl/rieger/outgoing/crlb.zip).
+- [Single emitter fitting](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/crlb.zip).
   Reference: C.S. Smith, N. Joseph, B. Rieger and K.A. Lidke,
   *Fast, single-molecule localization that achieves theoretically minimum uncertainty*,
   Nature Methods, **7**(5):373-375, 2010.
 
-- [TEM CCD camera characterization add-on](https://qiftp.tudelft.nl/diplib/addons/TEMcamerasV2.0.zip).
+- [TEM CCD camera characterization add-on](https://ftp.imphys.tudelft.nl/DIPimage/addons/TEMcamerasV2.0.zip).
   Reference: M. Vulović, B. Rieger, L.J. van Vliet, A.J. Koster and R.B.G. Ravelli,
   *A Toolkit for the Characterization of CCD cameras for Transmission Electron Microscopy*,
   Acta Crytallographica D., **66**:97-109, 2010.
 
-- [DNA analysis software add-on](ftp://qiftp.tudelft.nl/rieger/outgoing/WLCana.zip).
+- [DNA analysis software add-on](ftp://ftp.imphys.tudelft.nl/rieger/outgoing/WLCana.zip).
   Reference: F.G.A. Faas, B. Rieger, L.J. van Vliet and D.I. Cherny,
   *DNA deformations near charged surfaces: electron and atomic force microscopy views*,
   Biophysical Journal **97**(4):1148-1157, 2009.

--- a/download_2.9.md
+++ b/download_2.9.md
@@ -48,50 +48,50 @@ All versions have been tested on the following platforms:
 ## Download
 
 Please make sure you follow the installation instructions found in
-[the DIPimage User Manual](https://qiftp.tudelft.nl/diplib/latest/docs/dipimage_user_manual.pdf).
+[the DIPimage User Manual](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/dipimage_user_manual.pdf).
 
-- For Linux 32-bits: [dipimage_2.9_lin32.tbz](https://qiftp.tudelft.nl/diplib/2.9/dipimage_2.9_lin32.tbz).
-- For Linux 64-bits: [dipimage_2.9_lin64.tbz](https://qiftp.tudelft.nl/diplib/2.9/dipimage_2.9_lin64.tbz).
-- For MacOS X (10.6 or higher): [dipimage_2.9_darwin.tbz](https://qiftp.tudelft.nl/diplib/2.9/dipimage_2.9_darwin.tbz).
-- For Windows 64-bits [DIPimage 2.9 installer win64.exe](https://qiftp.tudelft.nl/diplib/2.9/DIPimage%202.9%20installer%20win64.exe)
-    (recommended) or [dipimage_2.9_win64.zip](https://qiftp.tudelft.nl/diplib/2.9/dipimage_2.9_win64.zip) (for manual installation).
+- For Linux 32-bits: [dipimage_2.9_lin32.tbz](https://ftp.imphys.tudelft.nl/DIPimage/2.9/dipimage_2.9_lin32.tbz).
+- For Linux 64-bits: [dipimage_2.9_lin64.tbz](https://ftp.imphys.tudelft.nl/DIPimage/2.9/dipimage_2.9_lin64.tbz).
+- For MacOS X (10.6 or higher): [dipimage_2.9_darwin.tbz](https://ftp.imphys.tudelft.nl/DIPimage/2.9/dipimage_2.9_darwin.tbz).
+- For Windows 64-bits [DIPimage 2.9 installer win64.exe](https://ftp.imphys.tudelft.nl/DIPimage/2.9/DIPimage%202.9%20installer%20win64.exe)
+    (recommended) or [dipimage_2.9_win64.zip](https://ftp.imphys.tudelft.nl/DIPimage/2.9/dipimage_2.9_win64.zip) (for manual installation).
 
 The set of demo images can be downloaded in two forms:
 
-- [images.tbz](https://qiftp.tudelft.nl/diplib/images.tbz) or
-- [images.zip](https://qiftp.tudelft.nl/diplib/images.zip).
+- [images.tbz](https://ftp.imphys.tudelft.nl/DIPimage/images.tbz) or
+- [images.zip](https://ftp.imphys.tudelft.nl/DIPimage/images.zip).
 
 Both files contain the same files, so you only need to download one format.
 
 *DIPimage* documentation:
 
-- [User Manual (PDF)](https://qiftp.tudelft.nl/diplib/latest/docs/dipimage_user_manual.pdf)
-- [Introduction to *DIPimage* (PDF)](https://qiftp.tudelft.nl/diplib/docs/Introduction_to_DIPimage.pdf)
+- [User Manual (PDF)](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/dipimage_user_manual.pdf)
+- [Introduction to *DIPimage* (PDF)](https://ftp.imphys.tudelft.nl/DIPimage/docs/Introduction_to_DIPimage.pdf)
 - Function reference is available within the toolbox
-- [MEX-file programming with *DIPimage* (PDF)](https://qiftp.tudelft.nl/diplib/latest/docs/mex_file_programming.pdf)
+- [MEX-file programming with *DIPimage* (PDF)](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/mex_file_programming.pdf)
 
 *DIPlib* documentation:
 
-- [Programmers Guide (PDF)](https://qiftp.tudelft.nl/diplib/latest/docs/diplib_programmers_guide.pdf)
-- [Function Reference (PDF)](https://qiftp.tudelft.nl/diplib/latest/docs/diplib_reference_guide.pdf) (~3Mb)
-- [Online Function Reference (HTML)](http://qiftp.tudelft.nl/dipref)
+- [Programmers Guide (PDF)](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/diplib_programmers_guide.pdf)
+- [Function Reference (PDF)](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/diplib_reference_guide.pdf) (~3Mb)
+- [Online Function Reference (HTML)](https://ftp.imphys.tudelft.nl/DIPimage/latest/docs/reference/)
 
 *DIPlib* sample source code:
 
-- [Sample stand-alone application in C](https://qiftp.tudelft.nl/diplib/docs/standalone.c)
-- [Same application without error-handling macros](https://qiftp.tudelft.nl/diplib/docs/standalone2.c)
-- [Demonstration of the measurement functions](https://qiftp.tudelft.nl/diplib/docs/measuredemo.c)
-- [Stand-alone application to create a thumbnail](https://qiftp.tudelft.nl/diplib/docs/makethumbs.c)
+- [Sample stand-alone application in C](https://ftp.imphys.tudelft.nl/DIPimage/docs/standalone.c)
+- [Same application without error-handling macros](https://ftp.imphys.tudelft.nl/DIPimage/docs/standalone2.c)
+- [Demonstration of the measurement functions](https://ftp.imphys.tudelft.nl/DIPimage/docs/measuredemo.c)
+- [Stand-alone application to create a thumbnail](https://ftp.imphys.tudelft.nl/DIPimage/docs/makethumbs.c)
    (this is a more complete and useful sample)
 
 ## Older releases
 
 Throughout time support for older versions of MATLAB has been dropped. Older releases of *DIPimage* might
 support these older versions. These can be found in their respective directories on our FTP site:
-<https://qiftp.tudelft.nl/diplib/>.
+<https://ftp.imphys.tudelft.nl/DIPimage/>.
 
 Also other older platforms have been supported in previous releases of *DIPlib* and *DIPimage*.
-These can be found here: <https://qiftp.tudelft.nl/diplib/unsupported>.
+These can be found here: <https://ftp.imphys.tudelft.nl/DIPimage/unsupported>.
 
 ## License
 
@@ -174,11 +174,11 @@ The licenses of these libraries expressly permit the embedding in commercial and
 They do require to mention the copyright with the application.
 For each library, the copyright can be downloaded below:
 
-- [gif license.txt](https://qiftp.tudelft.nl/diplib/licenses/gif_license.txt)
-- [ics license.txt](https://qiftp.tudelft.nl/diplib/licenses/ics_license.txt)
-- [jpeg license.txt](https://qiftp.tudelft.nl/diplib/licenses/jpeg_license.txt)
-- [tiff license.txt](https://qiftp.tudelft.nl/diplib/licenses/tiff_license.txt)
-- [zlib license.txt](https://qiftp.tudelft.nl/diplib/licenses/zlib_license.txt)
+- [gif license.txt](https://ftp.imphys.tudelft.nl/DIPimage/licenses/gif_license.txt)
+- [ics license.txt](https://ftp.imphys.tudelft.nl/DIPimage/licenses/ics_license.txt)
+- [jpeg license.txt](https://ftp.imphys.tudelft.nl/DIPimage/licenses/jpeg_license.txt)
+- [tiff license.txt](https://ftp.imphys.tudelft.nl/DIPimage/licenses/tiff_license.txt)
+- [zlib license.txt](https://ftp.imphys.tudelft.nl/DIPimage/licenses/zlib_license.txt)
 
 ### Request license
 

--- a/links.md
+++ b/links.md
@@ -8,11 +8,11 @@ author: "Cris Luengo"
 
 ## Learning image analysis
 
-- [*Image Analysis AP3471*](https://qiftp.tudelft.nl/diplib/docs/ipcourse.pdf), a manual for
+- [*Image Analysis AP3471*](https://ftp.imphys.tudelft.nl/DIPimage/docs/ipcourse.pdf), a manual for
   an elective M.Sc. course at TU Delft using *DIPimage*.
 
 - I.T. Young, J.J. Gerbrands, L.J. van Vliet,
-  "[*Fundamentals of Image Processing*](https://qiftp.tudelft.nl/diplib/docs/FIP2.3.pdf)",
+  "[*Fundamentals of Image Processing*](https://ftp.imphys.tudelft.nl/DIPimage/docs/FIP2.3.pdf)",
   an online image processing book.
 
 - A.K. Jain, "*Fundamentals of Digital Image Processing*", Prentice Hall, 1989.


### PR DESCRIPTION
The server `qiftp.tudelft.nl` is replaced with `ftp.imphys.tudelft.nl`. This pull request modifies the documentation accordingly.